### PR TITLE
#10 - Fix typo in method return type declaration

### DIFF
--- a/src/LtiOidcLogin.php
+++ b/src/LtiOidcLogin.php
@@ -124,13 +124,11 @@ class LtiOidcLogin
 
     /**
      * Validate the OIDC login request.
-     *
      * @param array $request
-     *
-     * @return Registration
+     * @return LtiRegistration
      * @throws OidcException
      */
-    public function validateOidcLogin($request): Registration
+    public function validateOidcLogin(array $request): LtiRegistration
     {
         // Validate Issuer.
         if (empty($request['iss'])) {


### PR DESCRIPTION
## Summary of Changes

This PR resolves the typo in the return type declaration for `LtiOidcLogin::validateOidcLogin()`

## Testing


- [ ] I have added automated tests for my changes
- [ ] I ran `composer test` before opening this PR
- [ ] I ran `composer lint-fix` before opening this PR
